### PR TITLE
Add support for building arm64 to macos package

### DIFF
--- a/tools/build.bat
+++ b/tools/build.bat
@@ -177,6 +177,7 @@ cd %ROOT_CODE_DIRECTORY%\chromium_git\chromium\src\cef
  --depot-tools-dir=%ROOT_CODE_DIRECTORY%\depot_tools^
  --branch=%BRANCH%^
  --with-pgo-profiles^
+ --no-chromium-history^
  --client-distrib^
  --distrib-subdir=%CEF_DISTRIB_SUBDIR%^
  --force-clean^


### PR DESCRIPTION
This is setup to package both an x86_64 and an arm64 sdk for darwin. Universal binary generation happens during dullahan packaging currently.